### PR TITLE
Add support for parsing !reference tag in GitLab CI YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ In additional to parsing YAML to AST, it has following features:
 
 * restoration after the errors and reporting errors as a part of AST nodes.
 * built-in support for `!include` tag used in RAML
+* built-in support fot `!reference` tag used in Gitlab CI.
 
 ## Usage
 The type information below is relevant when using TypeScript, if using from JavaScript only the field/method information is relevant.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The type information below is relevant when using TypeScript, if using from Java
 ### YAMLNode
 `YAMLNode` class is an ancestor for all node kinds.
 It's `kind` field determine node kind, one of `Kind` enum:
-  * `SCALAR`, `MAPPING`, `MAP`, `SEQ`, `ANCHOR_REF` or `INCLUDE_REF`.
+  * `SCALAR`, `MAPPING`, `MAP`, `SEQ`, `ANCHOR_REF`, `INCLUDE_REF` or `REFERENCE_REF`.
  
 After node kind is determined, it can be cast to one of the `YAMLNode` descendants types:
  * `YAMLScalar`, `YAMLMapping`, `YamlMap`, `YAMLSequence` or `YAMLAnchorReference`.

--- a/src/dumper.ts
+++ b/src/dumper.ts
@@ -227,6 +227,10 @@ function writeScalar(state, object, level) {
     state.dump=""+object;//FIXME
     return;
   }
+  if (object.indexOf("!reference")==0){
+    state.dump=""+object;//FIXME
+    return;
+  }
   if (object.indexOf("!$$$novalue")==0){
     state.dump="";//FIXME
     return;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1574,7 +1574,15 @@ function composeNode(state:State, parentIndent, nodeContext, allowToSeek, allowC
   }
 
   if (null !== state.tag && '!' !== state.tag) {
-    if (state.tag=="!include"){
+    if (state.tag == "!reference") {
+      if (!state.result) {
+        state.result = ast.newScalar();
+        state.result.startPosition = state.position;
+        state.result.endPosition = state.position;
+        throwError(state, "!reference without value");
+      }
+      state.result.kind = ast.Kind.REFERENCE_REF;
+    } else if (state.tag=="!include"){
         if (!state.result){
             state.result=ast.newScalar();
             state.result.startPosition=state.position;

--- a/src/yamlAST.ts
+++ b/src/yamlAST.ts
@@ -9,7 +9,8 @@ export enum Kind{
     MAP,
     SEQ,
     ANCHOR_REF,
-    INCLUDE_REF
+    INCLUDE_REF,
+    REFERENCE_REF
 }
 
 export interface YAMLDocument {


### PR DESCRIPTION
## Motivation and Context
This change is required to enable parsing of the `!reference` tag, which is used in GitLab CI YAML files to optimize and reuse YAML content. Currently, the `yaml-ast-parser` does not support parsing this tag, which leads to errors when validating GitLab CI files using Spectral. By adding support for `!reference`, this update will allow Spectral to handle GitLab's YAML references properly, improving compatibility with GitLab CI configurations.

Reference to the GitLab documentation:  [GitLab CI YAML Optimization Reference](https://docs.gitlab.com/ee/ci/yaml/yaml_optimization.html#reference-tags)

## Description
I have updated the `src/loader.ts` file to recognize the `!reference` tag alongside the existing tags like `!include`. The changes involve modifying the node kind and state when encountering `!reference` to correctly parse and handle it as a scalar or reference node, based on its context. I have also updated the `YAMLKind` enum in `src/yamlAST.ts` to include a `REFERENCE_REF` value, allowing the AST parser to distinguish between different types of reference tags.

## How Has This Been Tested?
The changes have been tested locally by parsing multiple GitLab CI YAML files containing the `!reference` tag. These tests confirmed that the parser now properly recognizes and handles these tags without producing errors. Additionally, I have manually verified the behavior against Spectral rules that validate such files.

Further automated tests will be implemented to cover a variety of cases where `!reference` tags are used in different contexts (e.g., scalar, sequence, mapping).

## Screenshot(s)/recording(s)
Not applicable.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](https://github.com/stoplightio/yaml-ast-parser).
- [] I have added error reporting and followed the error reporting guidelines.
- [x] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [] All new and existing tests pass locally (excluding flaky CI tests).
